### PR TITLE
Remove minimum from PathId schema.

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -168,7 +168,6 @@ components:
       schema:
         type: string
         format: uuid
-        minimum: 1
   requestBodies:
     ItemRequest:
       content:


### PR DESCRIPTION
The current config causes a compile error when generating a go *client* for the api. I think it's because the "type" is a string and the listed "minimum" is a number.