### PR TITLE
Fix TestFSNewInventoryTransaction related issues

### DIFF
--- a/backend/api-service/cloudbuild-test.yaml
+++ b/backend/api-service/cloudbuild-test.yaml
@@ -18,7 +18,7 @@ steps:
 # start the firestore emulator
 - name: gcr.io/cloud-builders/docker
   id: Start Firestore emulator
-  args: ['run', '--detach', '--rm', '--network=cloudbuild', '--name=firestore-emulator', 'jdlk7/firestore-emulator']
+  args: ['run', '--detach', '--rm', '--network=cloudbuild', '--name=firestore-emulator', 'google/cloud-sdk', 'sh', '-c', 'apt-get install google-cloud-sdk-firestore-emulator && gcloud beta emulators firestore start --host-port=0.0.0.0:9090']
 # wait for docker container to be serving
 - name: jwilder/dockerize:0.6.1
   id: Wait for Firestore emulator serving

--- a/backend/api-service/src/backend_firestore.go
+++ b/backend/api-service/src/backend_firestore.go
@@ -342,7 +342,7 @@ func (fb *FirestoreBackend) lookupInventory(ctx context.Context, itemID, locatio
 
 	// Lookup the inventory id
 	invs := client.Collection("inventories")
-	var inv *Inventory
+	inv := &Inventory{ItemId: itemID, LocationId: locationID}
 	err = client.RunTransaction(ctx, func(ctx context.Context, tx *firestore.Transaction) error {
 		// Find the inventory
 		q := invs.Where("ItemId", "==", itemID).Where("LocationId", "==", locationID)
@@ -356,7 +356,7 @@ func (fb *FirestoreBackend) lookupInventory(ctx context.Context, itemID, locatio
 		}
 
 		if len(docs) == 0 {
-			inv = &Inventory{ItemId: itemID, LocationId: locationID, LastUpdated: time.Now()}
+			inv.LastUpdated = time.Now()
 			return tx.Create(invs.NewDoc(), inv)
 		}
 

--- a/backend/api-service/src/backend_firestore_test.go
+++ b/backend/api-service/src/backend_firestore_test.go
@@ -170,10 +170,6 @@ func TestFSNewItem(t *testing.T) {
 }
 
 func TestFSNewInventoryTransaction(t *testing.T) {
-	// Running this test against the Firestore emulator raises an Unknown RPC
-	// error when querying the "inventories" collection not reproducible against
-	// an actual Firestore database:
-	t.Skip("this test is known to fail due to unknown reasons")
 	firestoreBackendTester.testNewInventoryTransaction(t)
 }
 

--- a/backend/api-service/src/backend_tester.go
+++ b/backend/api-service/src/backend_tester.go
@@ -724,7 +724,7 @@ func (bt *backendTester) testNewInventoryTransaction(t *testing.T) {
 			if !cmp.Equal(got, tc.txn, cmpopts.IgnoreFields(InventoryTransaction{}, "Id", "Timestamp")) {
 				t.Errorf("NewInventoryTransaction(%v) = %v want %v (ignoring Id field)", tc.txn, got, tc.txn)
 			}
-			if v, _ := backend.GetInventoryTransaction(ctx, got.Id); v != got {
+			if v, _ := backend.GetInventoryTransaction(ctx, got.Id); !cmp.Equal(got, v, cmpopts.EquateApproxTime(time.Microsecond)) {
 				t.Errorf("after backend.NewInventoryTransaction(%v), backend.GetInventoryTransaction(%v) = %v want %v", tc.txn, got.Id, v, got)
 			}
 

--- a/makefile
+++ b/makefile
@@ -100,7 +100,8 @@ lint: lint-webui
 
 test-backend-local: backend/api-service/src/api/openapi.yaml
 	docker stop firestore-emulator 2>/dev/null || true
-	docker run --detach --rm -p 9090:9090 --name=firestore-emulator jdlk7/firestore-emulator
+	docker run --detach --rm -p 9090:9090 --name=firestore-emulator google/cloud-sdk:292.0.0 sh -c \
+	 "apt-get install google-cloud-sdk-firestore-emulator && gcloud beta emulators firestore start --host-port=0.0.0.0:9090"
 	docker run --network=host jwilder/dockerize:0.6.1 dockerize -timeout=60s -wait=tcp://localhost:9090
 	cd backend/api-service/src && FIRESTORE_EMULATOR_HOST=localhost:9090 go test -tags=emulator -v
 	docker stop firestore-emulator


### PR DESCRIPTION
With the latest Cloud SDK the emulator issues have gone away and we can unskip this test (see my comment in #10).

I replaced usage of the firestore emulator image (which was failing with an older emulator version) with using the latest Cloud SDK image instead. Also fixed bugs the newly unskipped test unearthed.

Closes #10 