### PR TITLE
Run npm audit only on prod dependencies

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -58,7 +58,7 @@ jobs:
       with:
         node-version: '12.16.2'
     - working-directory: ./webui
-      run: npm audit
+      run: npm audit --production
   
   webui-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
`npm audit` checks started failing today due to a [security vulnerability](https://www.npmjs.com/advisories/1486) newly published. This only affects our dev dependencies and shouldn't block other PRs from submitting.