### PR TITLE
Evaluate makefile variables only at target execution time

### DIFF
--- a/env.mk.sample
+++ b/env.mk.sample
@@ -14,20 +14,12 @@ DOMAIN=my-zone.cloud-tutorial.dev
 GIT_USER_ID=GoogleCloudPlatform
 GIT_REPO_ID=cloud-run-anthos-reference-web-app
 
-# Cluster information
-CLUSTER_LOCATION=$(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name:$(CLUSTER_NAME)" --format="csv[no-heading](location)" )
-CLUSTER_GKE_VERSION=$(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name:$(CLUSTER_NAME)" --format="csv[no-heading](currentMasterVersion)")
-
-# Default location and GKE version for cluster creation
-ifeq ($(CLUSTER_LOCATION),)
-	CLUSTER_LOCATION=us-west1-a
-endif
-ifeq ($(CLUSTER_GKE_VERSION),)
-	CLUSTER_GKE_VERSION=1.15
-endif
+# Cluster information. Uses defaults if cluster does not exist
+CLUSTER_LOCATION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name:$(CLUSTER_NAME)" --format="value(location)" ), us-west1-a)
+CLUSTER_GKE_VERSION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name:$(CLUSTER_NAME)" --format="value(currentMasterVersion)"), 1.15)
 
 # Cloud DNS managed zone name
-MANAGED_ZONE_NAME=$(shell gcloud --project=$(PROJECT_ID) dns managed-zones list --format="csv[no-heading](name)" --filter="dnsName:$(DOMAIN)")
+MANAGED_ZONE_NAME=$(or $(shell gcloud --project=$(PROJECT_ID) dns managed-zones list --format="value(name)" --filter="dnsName:$(DOMAIN)d"), $(shell exit 1))
 
 # Namespace to be used by app and KCC resources
 NAMESPACE=app

--- a/makefile
+++ b/makefile
@@ -128,7 +128,7 @@ test-backend:
 	$(GCLOUD_BUILD) --config ./backend/api-service/cloudbuild-test.yaml --substitutions $(call join_subs,$(BACKEND_TEST_SUBS))
 
 test-webui:
-	$(GCLOUD_BUILD) --config ./webui/cloudbuild-test.yaml .
+	$(GCLOUD_BUILD) --config ./webui/cloudbuild-test.yaml
 
 test-webui-e2e:
 	$(GCLOUD_BUILD) --config ./webui/e2e/cloudbuild.yaml --substitutions $(call join_subs,$(FRONTEND_E2E_SUBS))
@@ -137,7 +137,7 @@ build-backend: cluster
 	$(GCLOUD_BUILD) --config ./backend/api-service/cloudbuild.yaml --substitutions $(call join_subs,$(BACKEND_SUBS))
 
 build-infrastructure: cluster
-	$(GCLOUD_BUILD) . --config cloudbuild.yaml --substitutions _APPLY_OR_DELETE=apply,$(call join_subs,$(INFRA_SUBS))
+	$(GCLOUD_BUILD) --config cloudbuild.yaml --substitutions _APPLY_OR_DELETE=apply,$(call join_subs,$(INFRA_SUBS))
 
 build-all: build-infrastructure build-webui build-backend
 

--- a/makefile
+++ b/makefile
@@ -113,8 +113,8 @@ GCLOUD_BUILD=gcloud --project=$(PROJECT_ID) builds submit $(MACHINE_TYPE) --verb
 
 cluster:
 	if ! gcloud --project=$(PROJECT_ID) container clusters describe $(CLUSTER_NAME) --zone $(CLUSTER_LOCATION) 2>&1 > /dev/null; then \
-	  echo Cluster $(CLUSTER_NAME) does not exist, creating cluster; \
-	  $(GCLOUD_BUILD) --config cloudbuild.yaml --substitutions $(call join_subs,$(PROVISION_SUBS)); \
+	  echo creating cluster $(CLUSTER_NAME); \
+	  $(GCLOUD_BUILD) --config cloudbuild-provision-cluster.yaml --substitutions $(call join_subs,$(PROVISION_SUBS)); \
 	  gcloud --project=$(PROJECT_ID) container clusters get-credentials $(CLUSTER_NAME) --zone $(CLUSTER_LOCATION); \
 	fi
 


### PR DESCRIPTION
This makes command line makefile target tab completion much faster (50-100x or so to tab complete `make clu` in the command line) than before as it won't be evaluating `gcloud` variables defined using `:=` or `ifeq`.

This was an annoying itch I decided to scratch :)

**Note**: The changes in `env.mk.sample` will need to be reflected in your personal `env.mk` so that the faster makefile tab completion takes effect (otherwise reading the makefile for tab completion will involve invoking three `gcloud` commands to get the cluster location/version and managed zone name)