### PR TITLE
Fix typo in env.mk.sample

### DIFF
--- a/env.mk.sample
+++ b/env.mk.sample
@@ -19,7 +19,7 @@ CLUSTER_LOCATION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters 
 CLUSTER_GKE_VERSION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name:$(CLUSTER_NAME)" --format="value(currentMasterVersion)"), 1.15)
 
 # Cloud DNS managed zone name
-MANAGED_ZONE_NAME=$(or $(shell gcloud --project=$(PROJECT_ID) dns managed-zones list --format="value(name)" --filter="dnsName:$(DOMAIN)d"), $(shell exit 1))
+MANAGED_ZONE_NAME=$(or $(shell gcloud --project=$(PROJECT_ID) dns managed-zones list --format="value(name)" --filter="dnsName:$(DOMAIN)"), $(shell exit 1))
 
 # Namespace to be used by app and KCC resources
 NAMESPACE=app


### PR DESCRIPTION
I forgot to delete this when I was testing `or` out 🤦 