### PR TITLE
Ensure cluster target fails on Cloud Build failure

### DIFF
--- a/makefile
+++ b/makefile
@@ -117,7 +117,7 @@ GCLOUD_BUILD=gcloud --project=$(PROJECT_ID) builds submit $(MACHINE_TYPE) --verb
 cluster:
 	if ! gcloud --project=$(PROJECT_ID) container clusters describe $(CLUSTER_NAME) --zone $(CLUSTER_LOCATION) 2>&1 > /dev/null; then \
 	  echo creating cluster $(CLUSTER_NAME); \
-	  $(GCLOUD_BUILD) --config cloudbuild-provision-cluster.yaml --substitutions $(call join_subs,$(PROVISION_SUBS)); \
+	  $(GCLOUD_BUILD) --config cloudbuild-provision-cluster.yaml --substitutions $(call join_subs,$(PROVISION_SUBS)) && \
 	  gcloud --project=$(PROJECT_ID) container clusters get-credentials $(CLUSTER_NAME) --zone $(CLUSTER_LOCATION); \
 	fi
 


### PR DESCRIPTION
It looks like there's a potential issue of the cluster target succeeding even if the overall cluster provision build failed. This seems to be due to the `if` statement being a one-liner with the `kubectl get-credentials` running regardless of the build outcome due to a `;`.

Per the [bash manual](https://www.gnu.org/software/bash/manual/bash.html#Lists),

> Commands separated by a ‘;’ are executed sequentially; the shell waits for each command to terminate in turn. The return status is the exit status of the last command executed.

Regardless of the build outcome, if the cluster is created, getting cluster credentials will still succeed if the cluster was created. 

The fix is to use `&&`, which depends on both operands to succeed.