### PR TITLE
Update README with "firebaseConfig.js" -> "firebaseConfig.ts"

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,11 +90,11 @@ This script:
      **Application homepage link** (your custom domain prefixed with `https://`).
    * Additional information
      [here](https://support.google.com/cloud/answer/6158849?hl=en#userconsent).
-1. Setup `webui/firebaseConfig.js`.
+1. Setup `webui/firebaseConfig.ts`.
    * Identify your Web API Key by navigating to Project Settings in the Firebase
      console:
      <https://console.firebase.google.com/project/$PROJECT_ID/settings/general>
-   * Run [firebase-config-setup.sh][] to create `webui/firebaseConfig.js`:
+   * Run [firebase-config-setup.sh][] to create `webui/firebaseConfig.ts`:
 
    ```bash
    ./scripts/firebase-config-setup.sh $PROJECT_ID $API_KEY


### PR DESCRIPTION
It was renamed in this PR: https://github.com/GoogleCloudPlatform/cloud-run-anthos-reference-web-app/pull/70