### PR TITLE
Run webui unit tests on push to any branch

### DIFF
--- a/.github/infra/webui-unittest-trigger.yaml
+++ b/.github/infra/webui-unittest-trigger.yaml
@@ -15,6 +15,9 @@
 name: pr-test-webui
 description: Test the UI components of the reference app
 filename: webui/cloudbuild-test.yaml
+includedFiles:
+- webui/**
+- .github/infra/**
 github:
   owner: GoogleCloudPlatform
   name: cloud-run-anthos-reference-web-app

--- a/.github/infra/webui-unittest-trigger.yaml
+++ b/.github/infra/webui-unittest-trigger.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pr-test-webui
+name: test-webui
 description: Test the UI components of the reference app
 filename: webui/cloudbuild-test.yaml
 includedFiles:

--- a/.github/infra/webui-unittest-trigger.yaml
+++ b/.github/infra/webui-unittest-trigger.yaml
@@ -18,6 +18,5 @@ filename: webui/cloudbuild-test.yaml
 github:
   owner: GoogleCloudPlatform
   name: cloud-run-anthos-reference-web-app
-  pullRequest:
-    commentControl: COMMENTS_DISABLED
-    branch: "^master$"
+  push:
+    branch: ".*"


### PR DESCRIPTION
Reconfigure the build trigger to run on push to any branch so that it will also run when PRs are merged to `master`. This allows code coverage reports to be generated for `master`.