### PR TITLE
fix waiting on transaction e2e feature.

### DIFF
--- a/webui/cypress/integration/features/inventory-transactions.feature
+++ b/webui/cypress/integration/features/inventory-transactions.feature
@@ -7,7 +7,7 @@ Feature: Inventory Transactions
     When I go to items page
     And I click on test item
     And wait for item to load
-    When I click on the plus icon button and wait
+    When I click on the plus icon button
     And I select test item
     And I select test location
     And I check radio button <action>

--- a/webui/cypress/support/step_definitions/base.steps.ts
+++ b/webui/cypress/support/step_definitions/base.steps.ts
@@ -69,10 +69,8 @@ When ('I click on link {string}', async (name) => {
 });
 
 
-When ('I click on the plus icon button and wait', async () => {
+When ('I click on the plus icon button', async () => {
   cy.get('button mat-icon').click();
-  cy.wait('@itemList');
-  cy.wait('@locationList');
 });
 
 When ('I submit the inventory transaction', () => {

--- a/webui/cypress/support/step_definitions/items.steps.ts
+++ b/webui/cypress/support/step_definitions/items.steps.ts
@@ -35,4 +35,6 @@ When('I go to items page', () => {
 When('wait for item to load', () => {
   cy.wait('@itemGet');
   cy.wait('@invTransList');
+  cy.wait('@itemList');
+  cy.wait('@locationList');
 });


### PR DESCRIPTION
Fix the waiting logic on inventory transaction e2e feature.

The loading of items and locations list was moved to the inventory transaction list page, and the dialog don't call those APIs anymore. So it should wait for those to finish before clicking the dialog button, not the other way around.