### PR TITLE
Use exact match filtering in gcloud commands

### DIFF
--- a/e2e/env.mk.template
+++ b/e2e/env.mk.template
@@ -11,11 +11,11 @@ GIT_REPO_ID=cloud-run-anthos-reference-web-app
 TEST_ARTIFACTS_LOCATION=crfa-reference-web-app-infra-e2e-artifacts
 
 # Cluster information. Uses defaults if cluster does not exist
-CLUSTER_LOCATION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name:$(CLUSTER_NAME)" --format="value(location)" ), us-west1-a)
-CLUSTER_GKE_VERSION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name:$(CLUSTER_NAME)" --format="value(currentMasterVersion)"), 1.15)
+CLUSTER_LOCATION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name=$(CLUSTER_NAME)" --format="value(location)" ), us-west1-a)
+CLUSTER_GKE_VERSION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name=$(CLUSTER_NAME)" --format="value(currentMasterVersion)"), 1.15)
 
 # Cloud DNS managed zone name
-MANAGED_ZONE_NAME=$(or $(shell gcloud --project=$(PROJECT_ID) dns managed-zones list --format="value(name)" --filter="dnsName:$(DOMAIN)"), $(shell exit 1))
+MANAGED_ZONE_NAME=$(or $(shell gcloud --project=$(PROJECT_ID) dns managed-zones list --format="value(name)" --filter="dnsName=$(DOMAIN)."), $(shell exit 1))
 
 # Namespace to be used by app and KCC resources
 NAMESPACE=app

--- a/env.mk.sample
+++ b/env.mk.sample
@@ -19,11 +19,11 @@ GIT_REPO_ID=cloud-run-anthos-reference-web-app
 TEST_ARTIFACTS_LOCATION=this.is.not.a.real.bucket
 
 # Cluster information. Uses defaults if cluster does not exist
-CLUSTER_LOCATION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name:$(CLUSTER_NAME)" --format="value(location)" ), us-west1-a)
-CLUSTER_GKE_VERSION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name:$(CLUSTER_NAME)" --format="value(currentMasterVersion)"), 1.15)
+CLUSTER_LOCATION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name=$(CLUSTER_NAME)" --format="value(location)" ), us-west1-a)
+CLUSTER_GKE_VERSION=$(or $(shell gcloud --project $(PROJECT_ID) container clusters list --filter="name=$(CLUSTER_NAME)" --format="value(currentMasterVersion)"), 1.15)
 
 # Cloud DNS managed zone name
-MANAGED_ZONE_NAME=$(or $(shell gcloud --project=$(PROJECT_ID) dns managed-zones list --format="value(name)" --filter="dnsName:$(DOMAIN)"), $(shell exit 1))
+MANAGED_ZONE_NAME=$(or $(shell gcloud --project=$(PROJECT_ID) dns managed-zones list --format="value(name)" --filter="dnsName=$(DOMAIN)."), $(shell exit 1))
 
 # Namespace to be used by app and KCC resources
 NAMESPACE=app

--- a/scripts/domain-setup.sh
+++ b/scripts/domain-setup.sh
@@ -77,7 +77,7 @@ echo "Using domain: [${DOMAIN}]."
 echo
 
 # Ensure a corresponding managed zone exists
-zone=$(gcloud --project "${PROJECT_ID}" dns managed-zones list --format="csv[no-heading](name)" --filter="dnsName:${DOMAIN}")
+zone=$(gcloud --project "${PROJECT_ID}" dns managed-zones list --format="csv[no-heading](name)" --filter="dnsName=${DOMAIN}.")
 if [[ -z "${zone}" ]]; then
   echo "No Cloud DNS Managed Zone corresponding to ${DOMAIN} found in ${PROJECT_ID}."
   echo "Please ensure your custom domain is associated with a Cloud DNS Managed Zone"


### PR DESCRIPTION
Per [`gcloud topic filters`](https://cloud.google.com/sdk/gcloud/reference/topic/filters#Operator-Terms), `key` `:` `simple-pattern` will evaluate True "if `key` contains `simple-pattern`" (deprecated default) or "if `simple-pattern` matches any `word` in `key`" (new implementation).

The new behavior of the `=` operator seems to be what we want. I've double checked that all gcloud commands we use use the new behavior.

Changes to `scripts/domain-setup.sh` have been verified and `env.mk.*` changes will be verified with an E2E run.