### PR TITLE
Remove mdivanova as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # the repo. Unless a later match takes precedence,
 # these users will be requested for
 # review when someone opens a pull request.
-*       @josueetcom @mdivanova @zsxking @ssmall @adamdkane
+*       @josueetcom @zsxking @ssmall @adamdkane


### PR DESCRIPTION
Since @mdivanova is no longer actively working on the project, she should not get automatically assigned to PRs.